### PR TITLE
midi_input.js - Fixed bug in removeEventListener

### DIFF
--- a/src/midi/midi_input.js
+++ b/src/midi/midi_input.js
@@ -65,7 +65,7 @@ export default class MIDIInput {
             return;
         }
 
-        if (listeners.has(listener) === false) {
+        if (listeners.has(listener) === true) {
             listeners.delete(listener);
         }
     }


### PR DESCRIPTION
The current implementation does not remove the listeners.
It checks if `listeners.has(listener) === false` - the opposite of what is desired.