### PR TITLE
midi_output.js - Fixed bug in removeEventListener

### DIFF
--- a/src/midi/midi_output.js
+++ b/src/midi/midi_output.js
@@ -92,7 +92,7 @@ export default class MIDIOutput {
             return;
         }
 
-        if (this._listeners.has(listener) === false) {
+        if (this._listeners.has(listener) === true) {
             this._listeners.delete(listener);
         }
     }


### PR DESCRIPTION
The current implementation does not remove the listeners.
It checks if `listeners.has(listener) === false` - the opposite of what is desired.